### PR TITLE
update php minimum to 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.1",
+        "php": ">=5.4.0",
         "symfony/process": "~2.1|~3.0"
     },
     "conflict": {


### PR DESCRIPTION
This patch updates the PHP minimum from 5.3.1->5.4 in the composer json file.